### PR TITLE
views.handle_xmlrpc: TypeError: context must be a dict rather than RequestContext (#7)

### DIFF
--- a/django_xmlrpc/views.py
+++ b/django_xmlrpc/views.py
@@ -43,8 +43,7 @@ from logging import getLogger
 
 from django.http import HttpResponse
 from django.http import HttpResponseServerError
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 
 from django_xmlrpc.decorators import xmlrpc_func
@@ -94,6 +93,4 @@ def handle_xmlrpc(request):
 
             method_list.append((method, sig, method_help))
 
-        return render_to_response(
-            'xmlrpc_get.html',
-            RequestContext(request, {'methods': method_list}))
+        return render(request, 'xmlrpc_get.html', {'methods': method_list})


### PR DESCRIPTION
Fixes #7

As of Django 1.10 (deprecated in Django 1.8), the `context` parameter of `django.shortcuts.render_to_response()` should be a `dict`, not a `ResponseContext` object [docs](https://docs.djangoproject.com/en/1.11/releases/1.8/#dictionary-and-context-instance-arguments-of-rendering-functions). Additionally, `django.shortcuts.render_to_response()` is "not recommended and is likely to be deprecated in the future" [docs](https://docs.djangoproject.com/en/1.11/topics/http/shortcuts/#render-to-response).

Therefore, I replaced the call to `django.shortcuts.render_to_response()` with `django.shortcuts.render()` (the preferred method) and refactored the `context` to a `dict`.

Let me know if you have any questions/comments!